### PR TITLE
ignore-new-AMI-version

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -181,7 +181,7 @@ resource "aws_instance" "cratedb_node" {
   }
 
   lifecycle {
-    ignore_changes = [user_data,ami]
+    ignore_changes = [user_data, ami]
   }
 
   tags = {

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -181,7 +181,7 @@ resource "aws_instance" "cratedb_node" {
   }
 
   lifecycle {
-    ignore_changes = [user_data]
+    ignore_changes = [user_data,ami]
   }
 
   tags = {

--- a/aws/ec2_utility.tf
+++ b/aws/ec2_utility.tf
@@ -148,7 +148,7 @@ resource "aws_instance" "utilities" {
   }
 
   lifecycle {
-    ignore_changes = [user_data]
+    ignore_changes = [user_data,ami]
   }
 
   tags = {

--- a/aws/ec2_utility.tf
+++ b/aws/ec2_utility.tf
@@ -148,7 +148,7 @@ resource "aws_instance" "utilities" {
   }
 
   lifecycle {
-    ignore_changes = [user_data,ami]
+    ignore_changes = [user_data, ami]
   }
 
   tags = {


### PR DESCRIPTION
This change prevents instances from being recreated because there is a newer version of the AMI.

## Summary of the changes / Why this is an improvement
In an already deployed environment, you want to prevent running Terraform apply results in a recreation of all the data and util nodes just because a new version of an AMI was released. 

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
