### PR TITLE
Update cloud-init-cratedb-tar.tftpl

### DIFF
--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -94,12 +94,13 @@ write_files:
       # Additional Java OPTS
       CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.0.0.jar=8080"
     owner: root:root
-    path: /etc/sysconfig/crate
+    path: /etc/default/crate
     permissions: "0755"
   - content: |
       [Unit]
       Description=CrateDB Server
-      Documentation=https://crate.io/docs
+      Documentation=https://crate.io/docs/
+      Wants=network.target
       After=network.target
 
       [Service]
@@ -111,7 +112,7 @@ write_files:
       # default environment variables
       Environment="CRATE_HOME=/opt/crate"
       # load environment
-      EnvironmentFile=-/etc/sysconfig/crate
+      EnvironmentFile=-/etc/default/crate
 
       ExecStart=/opt/crate/bin/crate
 
@@ -133,23 +134,11 @@ write_files:
       # When a JVM receives a SIGTERM signal it exits with code 143
       SuccessExitStatus=143 SIGTERM SIGKILL
 
-      # Override these settings with a file called
-      # /etc/systemd/system/crate.service.d/crate.conf and specify any changes
-
-      # Specifies the maximum number of bytes of memory that may be locked into RAM
       LimitMEMLOCK=infinity
-
-      # Specifies the maximum file descriptor number that can be opened by this process
       LimitNOFILE=262144
-
-      # Specifies the maximum number of processes
       LimitNPROC=4096
-
-      # Specifies the maximum file size
-      LimitFSIZE=infinity
-
-      # Specifies limit of virtual memory that can be used
       LimitAS=infinity
+
 
       [Install]
       WantedBy=multi-user.target

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -140,7 +140,7 @@ write_files:
       LimitMEMLOCK=infinity
 
       # Specifies the maximum file descriptor number that can be opened by this process
-      LimitNOFILE=65536
+      LimitNOFILE=262144
 
       # Specifies the maximum number of processes
       LimitNPROC=4096


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR syncs `LimitNOFILE` with  https://github.com/crate/distribute/commit/3df1ddab347ff1c62bee70f4cecc7fce75027b65

@hammerhead do we need an entry for `CRATE_HEAP_DUMP_PATH` ?

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
