### PR TITLE
More flexible heap setting / custom `crate.yml` settings

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -30,8 +30,8 @@ The main setup consists of the following steps:
 
       # CrateDB-specific configuration
       crate = {
-        # Java Heap size in GB available to CrateDB
-        heap_size_gb = 2
+        # Java Heap size available to CrateDB
+        heap_size = "2g"
 
         cluster_name = "crate-cluster"
 

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -44,7 +44,7 @@ data "cloudinit_config" "config" {
         crate_download_url     = var.cratedb_tar_download_url
         crate_user             = local.config.crate_username
         crate_pass             = local.cratedb_password
-        crate_heap_size        = var.crate.heap_size_gb
+        crate_heap_size        = var.crate.heap_size
         crate_cluster_name     = var.crate.cluster_name
         crate_cluster_size     = var.crate.cluster_size
         crate_nodes_ips        = indent(12, yamlencode(aws_network_interface.interface[*].private_ip))

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -52,6 +52,7 @@ data "cloudinit_config" "config" {
         crate_protocol         = var.crate.ssl_enable ? "https" : "http"
         crate_ssl_certificate  = base64encode(tls_self_signed_cert.ssl.cert_pem)
         crate_ssl_private_key  = base64encode(tls_private_key.ssl.private_key_pem)
+        cratedb_user_settings  = indent(8, yamlencode(var.cratedb_settings))
       }
     )
   }

--- a/aws/scripts/cloud-init-cratedb-rpm.tftpl
+++ b/aws/scripts/cloud-init-cratedb-rpm.tftpl
@@ -80,6 +80,8 @@ write_files:
         ssl.keystore_filepath: /etc/crate/keystore.p12
         ssl.keystore_password: changeit
         ssl.keystore_key_password: changeit
+
+        ${cratedb_user_settings}
     owner: root:root
     path: /etc/crate/crate.yml
     permissions: "0755"

--- a/aws/scripts/cloud-init-cratedb-rpm.tftpl
+++ b/aws/scripts/cloud-init-cratedb-rpm.tftpl
@@ -89,7 +89,7 @@ write_files:
       #   (e.g. 26g, stay below ~30G to benefit from CompressedOops)
       # - disable swapping my setting bootstrap.mlockall in crate.yml
       # Heap Size (defaults to 256m min, 1g max)
-      CRATE_HEAP_SIZE=${crate_heap_size}g
+      CRATE_HEAP_SIZE=${crate_heap_size}
 
       # Additional Java options
       CRATE_JAVA_OPTS="-javaagent:/usr/share/crate/crate-jmx-exporter-1.2.0.jar=8080"

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -71,6 +71,8 @@ write_files:
         ssl.keystore_filepath: /opt/crate/config/keystore.p12
         ssl.keystore_password: changeit
         ssl.keystore_key_password: changeit
+
+        ${cratedb_user_settings}
     owner: root:root
     path: /opt/crate/config/crate.yml
     permissions: "0755"

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -85,7 +85,7 @@ write_files:
       #   (e.g. 26g, stay below ~30G to benefit from CompressedOops)
       # - disable swapping my setting bootstrap.mlockall in crate.yml
       # Heap Size (defaults to 256m min, 1g max)
-      CRATE_HEAP_SIZE=${crate_heap_size}g
+      CRATE_HEAP_SIZE=${crate_heap_size}
 
       # Additional Java options
       CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.1.0.jar=8080"

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -88,7 +88,7 @@ write_files:
       CRATE_HEAP_SIZE=${crate_heap_size}
 
       # Additional Java options
-      CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.1.0.jar=8080"
+      CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.2.0.jar=8080"
     owner: root:root
     path: /etc/default/crate
     permissions: "0755"
@@ -166,7 +166,7 @@ runcmd:
   - tar -xf crate-*.tar.gz
   - mv -n crate-*/* /opt/crate
   - mv crate-*/config/log4j2.properties /opt/crate/config
-  - curl --output-dir /opt/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.1.0/crate-jmx-exporter-1.1.0.jar
+  - curl --output-dir /opt/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.2.0/crate-jmx-exporter-1.2.0.jar
   - chown -R crate:crate /opt/crate
   - systemctl daemon-reload
   - systemctl enable crate

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -18,14 +18,14 @@ variable "config" {
 
 variable "crate" {
   type = object({
-    heap_size_gb = number
+    heap_size    = string
     cluster_name = string
     cluster_size = number
     ssl_enable   = bool
   })
 
   default = {
-    heap_size_gb = 2
+    heap_size    = "2g"
     cluster_name = "CrateDB-Cluster"
     cluster_size = 3
     ssl_enable   = true

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -34,6 +34,12 @@ variable "crate" {
   description = "CrateDB application configuration"
 }
 
+variable "cratedb_settings" {
+  type        = map(string)
+  default     = {}
+  description = "CrateDB settings applied to crate.yml"
+}
+
 variable "cratedb_password" {
   type        = string
   default     = null


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

A few changes that are required for the latest benchmark post:

1. Generalize heap size input parameter to also accept values such as `30500m`
2. Allow passing additional `crate.yml` settings, e.g. to increase `thread_pool.write.queue_size` 

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
